### PR TITLE
Merging with main repo part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Temporary directory for test execution
 tmp/
+
+node_modules
+.idea

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -83,3 +83,5 @@ export function preprocessor(options = browserify.defaultOptions) {
     return browserify(options)(file);
   };
 }
+
+export default preprocessor

--- a/lib/methods.ts
+++ b/lib/methods.ts
@@ -1,13 +1,11 @@
 import registry from "./registry";
 
 const {
-  Given,
-  When,
-  Then,
+  defineStep,
   Step,
   defineParameterType,
   Before,
   After,
 } = registry.methods;
 
-export { Given, When, Then, Step, defineParameterType, Before, After };
+export { defineStep as Given, defineStep as When, defineStep as Then, defineStep as And, defineStep as But, defineStep, Step, defineParameterType, Before, After };

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -54,15 +54,7 @@ function parseHookArguments(
 
 export class Registry {
   public methods: {
-    Given<T extends unknown[]>(
-      description: string | RegExp,
-      body: IStepDefinitionBody<T>
-    ): void;
-    When<T extends unknown[]>(
-      description: string | RegExp,
-      body: IStepDefinitionBody<T>
-    ): void;
-    Then<T extends unknown[]>(
+    defineStep<T extends unknown[]>(
       description: string | RegExp,
       body: IStepDefinitionBody<T>
     ): void;
@@ -88,9 +80,7 @@ export class Registry {
 
   constructor() {
     this.methods = {
-      Given: this.defineStep.bind(this),
-      When: this.defineStep.bind(this),
-      Then: this.defineStep.bind(this),
+      defineStep: this.defineStep.bind(this),
       Step: this.runStepDefininition.bind(this),
       defineParameterType: this.defineParameterType.bind(this),
       Before: this.defineBefore.bind(this),


### PR DESCRIPTION
Hello there. 

So, I was hoping to merge your code in this week and go from there but I think it would be nice to first do some changes to allow as much backward compatibility as possible (in the constraints that we agreed upon in terms of what we are not going to support anymore). That was not realistic :) (I'm bad at always underestimating tasks..)

The changes in this PR allowed me to run all our existing tests with the global step definitions configuration. Here is a repo to play around:
https://github.com/TheBrainFamily/new-cypress-preprocessor-test-repo

I would rather not do the default export, and keep things as you had, but I think it's a small price to pay for keeping it backward compatible.

I think we can adjust some things  like that moving forward but I'd like to have as many people on the new version as soon as possible, and then possibly introduce another version with a cleanup. I think that if we throw too many obstacles in people path they will stay on the older versions and keep creating issues for them :)

My main goal is to make the code more maintainable, because with the number of active users this seems like a priority :)
That's why I feel like some of the backward-compatibility woudl be nice. But, definitely not crazy reporters that gets "sprinkled" all around the code. 

Besides that I noticed you removed some ways of defining steps, but as they are valid in cucumber, cheap to have (in terms of maintanance), then why not?

https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/api_reference.md#definesteppattern-options-fn

I'm actually not sure if the And/But is there, but defineStep definitely is there, and I think the And/But are nice to have, what do you think?

Moving forward I'd also like to add:
prettier
eslint
commitzen (although different one than we have currently)
semantic-release for an automated release (for that it'd be great to have eslint/prettier and commitizen ;) )

I was also considering adding the steps.js file with exports, that would be basically a rexport of your methods.ts. 
I like the methods.ts more - but I think this is again small enough to not be problematic, and would allow people to update without problems.

We could obviously write a codemod that would change all the imports, but knowing all the crazy stuff people do with the preprocessor (using step definitions as modules in node_modules, etc), it will not catch 100% cases.

As for nonGlobal/global way of working. Moving forward I'd like to make the nonGlobal default (as it was promised long time ago and most people seem to use that mode). But for now I'd like to use the current configuration option (nonGlobalStepDefinitions). It's ugly, and unnecessary if that's the default, but, again, it's backward compatible :) 
We could show your way of configuration in the documentation, while having the old one work (we could show depreciation warning)

In general, my plan would be to:
a) release a version based on your code, but with as many things backward compatible as possible (but, only things we want to support moving forward). This will be so most people can update without tweaking with the code, and it would get them on a version of code that we will keep maintaining, and that already fixes some bugs.
b) quickly release another release with backward incompatible changes, write a codemod and migration documentation. 

This way, if people create issues related to version A we can still debug and fix them, and they will have a reason to go through a migration, knowing that their bug was fixed in a newer version.
If people create issues related to version that's there currently, we will first ask them to upgrade to A - there should be minimum changes, and if the bug is fixed there - great, if not - we have a much easier way to reproduce and fix.

Please let me know what you think and if that plan sounds reasonable to you. I'm not asking or expecting you to do any of this work, but mainly want to check that it's possibly in line with your plans.

I will keep looking today and next week 

As always - thanks for your great work here!