### PR TITLE
Cypress tags executable

### DIFF
--- a/cypress-tags.sh
+++ b/cypress-tags.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+set -e
+
+specs=$(npx specs-by-tags "$@")
+
+case $1 in
+  "") exec npx cypress run --spec $specs ;;
+  -*) exec npx cypress run --spec $specs "$@" ;;
+   *) exec "$@" --spec $specs ;;
+esac

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -7,3 +7,10 @@ export function assertAndReturn<T>(
   assert(value, message);
   return value;
 }
+
+export function assertIsString(
+  value: any,
+  message: string
+): asserts value is string {
+  assert(typeof value === "string", message);
+}

--- a/lib/ast-helpers.ts
+++ b/lib/ast-helpers.ts
@@ -1,5 +1,7 @@
 import { messages } from "@cucumber/messages";
 
+import { assertAndReturn } from "./assertions";
+
 export function* traverseGherkinDocument(
   gherkinDocument: messages.IGherkinDocument
 ) {
@@ -200,4 +202,8 @@ function* traverseExample(
       yield* traverseRow(row);
     }
   }
+}
+
+export function mapTagName(value: { name?: string | null }) {
+  return assertAndReturn(value.name, "Expected tag to have a name");
 }

--- a/lib/create-tests.ts
+++ b/lib/create-tests.ts
@@ -8,15 +8,11 @@ import { assertAndReturn } from "./assertions";
 
 import registry from "./registry";
 
-import { traverseGherkinDocument } from "./ast-helpers";
+import { traverseGherkinDocument, mapTagName } from "./ast-helpers";
 
 import { YieldType } from "./types";
 
 type Node = ReturnType<typeof parse>;
-
-function mapTagName(value: { name?: string | null }) {
-  return assertAndReturn(value.name, "Expected tag to have a name");
-}
 
 function createFeature(
   gherkinDocument: messages.IGherkinDocument,

--- a/lib/cypress-configuration.test.ts
+++ b/lib/cypress-configuration.test.ts
@@ -1,0 +1,497 @@
+import fs from "fs";
+
+import path from "path";
+
+import util from "util";
+
+import assert from "assert";
+
+import {
+  resolveConfiguration,
+  resolveEnvironment,
+} from "./cypress-configuration";
+
+interface CypressConfig {
+  [key: string]: string | CypressConfig;
+}
+
+interface CypressEnvConfig {
+  [key: string]: string;
+}
+
+function example<T extends object>(
+  method: (options: T) => any,
+  options: T & {
+    cypressConfig?: CypressConfig;
+    cypressConfigPath?: string;
+    cypressEnvConfig?: CypressEnvConfig;
+  },
+  attribute: string,
+  expected: any
+) {
+  it(`should return ${attribute} = "${expected}" for ${util.inspect(
+    options
+  )}}`, () => {
+    const {
+      cypressConfig,
+      cypressConfigPath = "cypress.json",
+      cypressEnvConfig,
+    } = options;
+
+    const cwd = path.join(process.cwd(), "tmp", "unit");
+
+    fs.rmdirSync(cwd, { recursive: true });
+    fs.mkdirSync(cwd, { recursive: true });
+
+    if (cypressConfig) {
+      fs.writeFileSync(
+        path.join(cwd, cypressConfigPath),
+        JSON.stringify(cypressConfig, null, 2)
+      );
+    }
+
+    if (cypressEnvConfig) {
+      fs.writeFileSync(
+        path.join(cwd, "cypress.env.json"),
+        JSON.stringify(cypressEnvConfig, null, 2)
+      );
+    }
+
+    const actual = method({
+      argv: [],
+      env: {},
+      cwd,
+      ...options,
+    });
+
+    assert.strictEqual(actual[attribute], expected);
+  });
+}
+
+describe("resolveConfiguration()", () => {
+  // Default
+  example(resolveConfiguration, {}, "integrationFolder", "cypress/integration");
+  example(resolveConfiguration, {}, "fixturesFolder", "cypress/fixtures");
+  example(resolveConfiguration, {}, "supportFile", "cypress/support/index.js");
+  example(resolveConfiguration, {}, "testFiles", "**/*.*");
+  example(resolveConfiguration, {}, "ignoreTestFiles", "*.hot-update.js");
+
+  // Simple CLI override
+  example(
+    resolveConfiguration,
+    {
+      argv: ["--config", "integrationFolder=foo/bar"],
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: ["--config=integrationFolder=foo/bar"],
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: ["-c", "integrationFolder=foo/bar"],
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+
+  // CLI override with preceding, comma-delimited configuration
+  example(
+    resolveConfiguration,
+    {
+      argv: ["--config", "foo=bar,integrationFolder=foo/bar"],
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: ["--config=foo=bar,integrationFolder=foo/bar"],
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: ["-c", "foo=bar,integrationFolder=foo/bar"],
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+
+  // CLI override with succeeding, comma-delimited configuration
+  example(
+    resolveConfiguration,
+    {
+      argv: ["--config", "integrationFolder=foo/bar,foo=bar"],
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: ["--config=integrationFolder=foo/bar,foo=bar"],
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: ["-c", "integrationFolder=foo/bar,foo=bar"],
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+
+  // CLI override with last match taking precedence
+  example(
+    resolveConfiguration,
+    {
+      argv: [
+        "--config",
+        "integrationFolder=baz",
+        "--config",
+        "integrationFolder=foo/bar",
+      ],
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: [
+        "--config=integrationFolder=baz",
+        "--config=integrationFolder=foo/bar",
+      ],
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: ["-c", "integrationFolder=baz", "-c", "integrationFolder=foo/bar"],
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+
+  const envTestMatrix: { env: Record<string, string>; expected: string }[] = [
+    {
+      env: {
+        CYPRESS_integrationFolder: "foo/bar",
+      },
+      expected: "foo/bar",
+    },
+    {
+      env: {
+        cypress_integrationFolder: "foo/bar",
+      },
+      expected: "foo/bar",
+    },
+    {
+      env: {
+        CYPRESS_integration_folder: "foo/bar",
+      },
+      expected: "foo/bar",
+    },
+    {
+      env: {
+        cypress_integration_folder: "foo/bar",
+      },
+      expected: "foo/bar",
+    },
+    {
+      env: {
+        CYPRESS_INTEGRATION_FOLDER: "foo/bar",
+      },
+      expected: "foo/bar",
+    },
+    {
+      env: {
+        cypress_INTEGRATION_FOLDER: "foo/bar",
+      },
+      expected: "foo/bar",
+    },
+    // Erroneous camelcase
+    {
+      env: {
+        CYPRESS_integrationfolder: "foo/bar",
+      },
+      expected: "cypress/integration",
+    },
+    {
+      env: {
+        cypress_integrationfolder: "foo/bar",
+      },
+      expected: "cypress/integration",
+    },
+  ];
+
+  for (let { env, expected } of envTestMatrix) {
+    example(
+      resolveConfiguration,
+      {
+        env,
+      },
+      "integrationFolder",
+      expected
+    );
+  }
+
+  // Override with cypress.json
+  example(
+    resolveConfiguration,
+    {
+      cypressConfig: { integrationFolder: "foo/bar" },
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+
+  // Override with cypress.json in custom location
+  example(
+    resolveConfiguration,
+    {
+      argv: ["--config-file", "foo.json"],
+      cypressConfig: { integrationFolder: "foo/bar" },
+      cypressConfigPath: "foo.json",
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: ["--config-file=foo.json"],
+      cypressConfig: { integrationFolder: "foo/bar" },
+      cypressConfigPath: "foo.json",
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: ["-C", "foo.json"],
+      cypressConfig: { integrationFolder: "foo/bar" },
+      cypressConfigPath: "foo.json",
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+});
+
+describe("resolveEnvironment()", () => {
+  // Default
+  example(resolveEnvironment, {}, "FOO", undefined);
+
+  // Simple CLI override
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--env", "FOO=foo"],
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--env=FOO=foo"],
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["-e", "FOO=foo"],
+    },
+    "FOO",
+    "foo"
+  );
+
+  // CLI override with preceding, comma-delimited configuration
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--env", "BAR=bar,FOO=foo"],
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--env=BAR=bar,FOO=foo"],
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["-e", "BAR=bar,FOO=foo"],
+    },
+    "FOO",
+    "foo"
+  );
+
+  // CLI override with succeeding, comma-delimited configuration
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--env", "FOO=foo,BAR=bar"],
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--env=FOO=foo,BAR=bar"],
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["-e", "FOO=foo,BAR=bar"],
+    },
+    "FOO",
+    "foo"
+  );
+
+  // CLI override with last match taking precedence
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--env", "FOO=baz", "--env", "FOO=foo"],
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--env=FOO=baz", "--env=FOO=foo"],
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["-e", "FOO=baz", "-e", "FOO=foo"],
+    },
+    "FOO",
+    "foo"
+  );
+
+  const envTestMatrix: {
+    env: Record<string, string>;
+    expected: string | undefined;
+  }[] = [
+    {
+      env: {
+        CYPRESS_FOO: "foo",
+      },
+      expected: "foo",
+    },
+    {
+      env: {
+        cypress_FOO: "foo",
+      },
+      expected: "foo",
+    },
+    {
+      env: {
+        CYPRESS_foo: "foo",
+      },
+      expected: undefined,
+    },
+    {
+      env: {
+        cypress_foo: "foo",
+      },
+      expected: undefined,
+    },
+  ];
+
+  for (let { env, expected } of envTestMatrix) {
+    example(
+      resolveEnvironment,
+      {
+        env,
+      },
+      "FOO",
+      expected
+    );
+  }
+
+  // Override with cypress.json
+  example(
+    resolveEnvironment,
+    {
+      cypressConfig: { env: { FOO: "foo" } },
+    },
+    "FOO",
+    "foo"
+  );
+
+  // Override with cypress.json in custom location
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--config-file", "foo.json"],
+      cypressConfig: { env: { FOO: "foo" } },
+      cypressConfigPath: "foo.json",
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--config-file=foo.json"],
+      cypressConfig: { env: { FOO: "foo" } },
+      cypressConfigPath: "foo.json",
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["-C", "foo.json"],
+      cypressConfig: { env: { FOO: "foo" } },
+      cypressConfigPath: "foo.json",
+    },
+    "FOO",
+    "foo"
+  );
+
+  // Override with cypress.env.json
+  example(
+    resolveEnvironment,
+    {
+      cypressEnvConfig: { FOO: "foo" },
+    },
+    "FOO",
+    "foo"
+  );
+});

--- a/lib/cypress-configuration.test.ts
+++ b/lib/cypress-configuration.test.ts
@@ -24,6 +24,7 @@ function example<T extends object>(
   options: T & {
     cypressConfig?: CypressConfig;
     cypressConfigPath?: string;
+    cypressProjectPath?: string;
     cypressEnvConfig?: CypressEnvConfig;
   },
   attribute: string,
@@ -36,23 +37,28 @@ function example<T extends object>(
       cypressConfig,
       cypressConfigPath = "cypress.json",
       cypressEnvConfig,
+      cypressProjectPath,
     } = options;
 
     const cwd = path.join(process.cwd(), "tmp", "unit");
 
+    const fullCypressProjectPath = cypressProjectPath
+      ? path.join(cwd, cypressProjectPath)
+      : cwd;
+
     fs.rmdirSync(cwd, { recursive: true });
-    fs.mkdirSync(cwd, { recursive: true });
+    fs.mkdirSync(fullCypressProjectPath, { recursive: true });
 
     if (cypressConfig) {
       fs.writeFileSync(
-        path.join(cwd, cypressConfigPath),
+        path.join(fullCypressProjectPath, cypressConfigPath),
         JSON.stringify(cypressConfig, null, 2)
       );
     }
 
     if (cypressEnvConfig) {
       fs.writeFileSync(
-        path.join(cwd, "cypress.env.json"),
+        path.join(fullCypressProjectPath, "cypress.env.json"),
         JSON.stringify(cypressEnvConfig, null, 2)
       );
     }
@@ -292,6 +298,73 @@ describe("resolveConfiguration()", () => {
     "integrationFolder",
     "foo/bar"
   );
+
+  // Override with cypress.json & custom project path.
+  example(
+    resolveConfiguration,
+    {
+      argv: ["--project", "foo"],
+      cypressConfig: { integrationFolder: "foo/bar" },
+      cypressProjectPath: "foo",
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: ["--project=foo"],
+      cypressConfig: { integrationFolder: "foo/bar" },
+      cypressProjectPath: "foo",
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: ["-P", "foo"],
+      cypressConfig: { integrationFolder: "foo/bar" },
+      cypressProjectPath: "foo",
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+
+  // Override with cypress.json in custom location & custom project path.
+  example(
+    resolveConfiguration,
+    {
+      argv: ["--config-file", "foo.json", "--project", "foo"],
+      cypressConfig: { integrationFolder: "foo/bar" },
+      cypressConfigPath: "foo.json",
+      cypressProjectPath: "foo",
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: ["--config-file=foo.json", "--project", "foo"],
+      cypressConfig: { integrationFolder: "foo/bar" },
+      cypressConfigPath: "foo.json",
+      cypressProjectPath: "foo",
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
+  example(
+    resolveConfiguration,
+    {
+      argv: ["-C", "foo.json", "--project", "foo"],
+      cypressConfig: { integrationFolder: "foo/bar" },
+      cypressConfigPath: "foo.json",
+      cypressProjectPath: "foo",
+    },
+    "integrationFolder",
+    "foo/bar"
+  );
 });
 
 describe("resolveEnvironment()", () => {
@@ -490,6 +563,105 @@ describe("resolveEnvironment()", () => {
     resolveEnvironment,
     {
       cypressEnvConfig: { FOO: "foo" },
+    },
+    "FOO",
+    "foo"
+  );
+
+  // Override with cypress.json & custom project path.
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--project", "foo"],
+      cypressConfig: { env: { FOO: "foo" } },
+      cypressProjectPath: "foo",
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--project=foo"],
+      cypressConfig: { env: { FOO: "foo" } },
+      cypressProjectPath: "foo",
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["-P", "foo"],
+      cypressConfig: { env: { FOO: "foo" } },
+      cypressProjectPath: "foo",
+    },
+    "FOO",
+    "foo"
+  );
+
+  // Override with cypress.json in custom location & custom project path.
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--project", "foo", "--config-file", "foo.json"],
+      cypressConfig: { env: { FOO: "foo" } },
+      cypressConfigPath: "foo.json",
+      cypressProjectPath: "foo",
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--project=foo", "--config-file", "foo.json"],
+      cypressConfig: { env: { FOO: "foo" } },
+      cypressConfigPath: "foo.json",
+      cypressProjectPath: "foo",
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["-P", "foo", "--config-file", "foo.json"],
+      cypressConfig: { env: { FOO: "foo" } },
+      cypressConfigPath: "foo.json",
+      cypressProjectPath: "foo",
+    },
+    "FOO",
+    "foo"
+  );
+
+  // Override with cypress.env.json & custom project path.
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--project", "foo"],
+      cypressEnvConfig: { FOO: "foo" },
+      cypressProjectPath: "foo",
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["--project=foo"],
+      cypressEnvConfig: { FOO: "foo" },
+      cypressProjectPath: "foo",
+    },
+    "FOO",
+    "foo"
+  );
+  example(
+    resolveEnvironment,
+    {
+      argv: ["-P", "foo"],
+      cypressEnvConfig: { FOO: "foo" },
+      cypressProjectPath: "foo",
     },
     "FOO",
     "foo"

--- a/lib/cypress-configuration.ts
+++ b/lib/cypress-configuration.ts
@@ -1,0 +1,287 @@
+import fs from "fs";
+
+import path from "path";
+
+import util from "util";
+
+import assert from "assert";
+
+import debug from "./debug";
+import { assertAndReturn } from "./assertions";
+
+/**
+ * This is obviously a non-exhaustive list.
+ */
+const RECOGNIZED_CONFIGURATION_ATTRIBUTES = [
+  "integrationFolder",
+  "fixturesFolder",
+  "supportFile",
+  "testFiles",
+  "ignoreTestFiles",
+];
+
+export function findLastIndex<T>(
+  collection: ArrayLike<T>,
+  predicate: (value: T) => boolean,
+  beforeIndex = collection.length
+): number {
+  for (let i = beforeIndex - 1; i >= 0; --i) {
+    if (predicate(collection[i])) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+export function* traverseArgvMatching(
+  argv: string[],
+  name: string,
+  allowEqual: boolean
+) {
+  let beforeIndex = argv.length,
+    matchingIndex;
+
+  while (
+    (matchingIndex = findLastIndex(
+      argv,
+      (arg) => arg.startsWith(name),
+      beforeIndex
+    )) !== -1
+  ) {
+    if (argv[matchingIndex] === name) {
+      if (argv.length - 1 === matchingIndex) {
+        debug(`'${name}' argument missing`);
+      } else {
+        yield argv[matchingIndex + 1];
+      }
+    } else if (allowEqual && argv[matchingIndex][name.length] === "=") {
+      yield argv[matchingIndex].slice(name.length + 1);
+    }
+
+    beforeIndex = matchingIndex;
+  }
+}
+
+export function* combine<T>(...generators: Generator<T, unknown, unknown>[]) {
+  for (const generator of generators) {
+    yield* generator;
+  }
+}
+
+export function findArgumentValue(
+  argv: string[],
+  name: string,
+  allowEqual: boolean
+): string | undefined {
+  for (const value of traverseArgvMatching(argv, name, allowEqual)) {
+    return value;
+  }
+}
+
+export function toSnakeCase(value: string) {
+  return value.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+}
+
+export function capitalize(word: string) {
+  return word.toLowerCase().replace(/\b\w/g, (l) => l.toUpperCase());
+}
+
+export function toCamelCase(value: string) {
+  return value
+    .split("_")
+    .map((word, index) =>
+      index === 0 ? word.toLocaleLowerCase() : capitalize(word)
+    )
+    .join("");
+}
+
+export function resolveConfiguration(options: {
+  argv?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+}): Record<string, any> {
+  const {
+    argv = process.argv,
+    env = process.env as Record<string, string>,
+    cwd = process.cwd(),
+  } = options;
+
+  const cliOrigin: Record<string, string> = Object.fromEntries(
+    Array.from(
+      combine(
+        traverseArgvMatching(argv, "--config", true),
+        traverseArgvMatching(argv, "-c", false)
+      )
+    )
+      .reverse()
+      .flatMap((argument) => {
+        const keypairExpr = /(?:^|,)([^=]+)=([^,$]+)/g;
+        const entries: [string, string][] = [];
+        let match;
+
+        while ((match = keypairExpr.exec(argument)) !== null) {
+          if (RECOGNIZED_CONFIGURATION_ATTRIBUTES.includes(match[1])) {
+            entries.push([match[1], match[2]]);
+          }
+        }
+
+        return entries;
+      })
+  );
+
+  const envPrefixExpr = /^cypress_(.+)/i;
+
+  const envOrigin: Record<string, string> = Object.fromEntries(
+    Object.entries(env)
+      .filter((entry) => {
+        return envPrefixExpr.test(entry[0]);
+      })
+      .map<[string, string]>((entry) => {
+        const match = entry[0].match(envPrefixExpr);
+
+        assert(
+          match,
+          "cypress-cucumber-preprocessor: expected match after test"
+        );
+
+        return [assertAndReturn(match[1]), entry[1]];
+      })
+      .map((entry) => {
+        return [
+          entry[0].includes("_") ? toCamelCase(entry[0]) : entry[0],
+          entry[1],
+        ];
+      })
+      .filter((entry) => {
+        return RECOGNIZED_CONFIGURATION_ATTRIBUTES.includes(entry[0]);
+      })
+  );
+
+  let configOrigin: Record<string, any> = {};
+
+  const cypressConfigPath = path.join(cwd, resolveConfigurationFile(options));
+
+  if (fs.existsSync(cypressConfigPath)) {
+    const content = fs.readFileSync(cypressConfigPath).toString("utf8");
+
+    configOrigin = JSON.parse(content);
+  }
+
+  const configuration = Object.assign(
+    {
+      integrationFolder: "cypress/integration",
+      fixturesFolder: "cypress/fixtures",
+      supportFile: "cypress/support/index.js",
+      testFiles: "**/*.*",
+      ignoreTestFiles: "*.hot-update.js",
+    },
+    configOrigin,
+    envOrigin,
+    cliOrigin
+  );
+
+  debug(`resolved configuration of ${util.inspect(configuration)}`);
+
+  return configuration;
+}
+
+export function resolveEnvironment(options: {
+  argv?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+}): any {
+  const {
+    argv = process.argv,
+    env = process.env as Record<string, string>,
+    cwd = process.cwd(),
+  } = options;
+
+  const cliOrigin: Record<string, string> = Object.fromEntries(
+    Array.from(
+      combine(
+        traverseArgvMatching(argv, "--env", true),
+        traverseArgvMatching(argv, "-e", false)
+      )
+    )
+      .reverse()
+      .flatMap((argument) => {
+        const keypairExpr = /(?:^|,)([^=]+)=([^,$]+)/g;
+        const entries: [string, string][] = [];
+        let match;
+
+        while ((match = keypairExpr.exec(argument)) !== null) {
+          entries.push([match[1], match[2]]);
+        }
+
+        return entries;
+      })
+  );
+
+  const envPrefixExpr = /^cypress_(.+)/i;
+
+  const envOrigin: Record<string, string> = Object.fromEntries(
+    Object.entries(env)
+      .filter((entry) => {
+        return envPrefixExpr.test(entry[0]);
+      })
+      .map<[string, string]>((entry) => {
+        const match = entry[0].match(envPrefixExpr);
+
+        assert(
+          match,
+          "cypress-cucumber-preprocessor: expected match after test"
+        );
+
+        return [assertAndReturn(match[1]), entry[1]];
+      })
+  );
+
+  const cypressConfigPath = path.join(cwd, resolveConfigurationFile(options));
+
+  let configOrigin: Record<string, any> = {};
+
+  if (fs.existsSync(cypressConfigPath)) {
+    const content = fs.readFileSync(cypressConfigPath).toString("utf8");
+
+    const cypressConfig = JSON.parse(content);
+
+    if (cypressConfig.env) {
+      configOrigin = cypressConfig.env;
+    }
+  }
+
+  const cypressEnvironmentFilePath = path.join(cwd, "cypress.env.json");
+
+  let cypressEnvOrigin: Record<string, any> = {};
+
+  if (fs.existsSync(cypressEnvironmentFilePath)) {
+    const content = fs
+      .readFileSync(cypressEnvironmentFilePath)
+      .toString("utf8");
+
+    cypressEnvOrigin = JSON.parse(content);
+  }
+
+  const environment = Object.assign(
+    {},
+    cypressEnvOrigin,
+    configOrigin,
+    envOrigin,
+    cliOrigin
+  );
+
+  debug(`resolved environment of ${util.inspect(environment)}`);
+
+  return environment;
+}
+
+export function resolveConfigurationFile(options: { argv?: string[] }): string {
+  const { argv = process.argv } = options;
+
+  return (
+    findArgumentValue(argv, "--config-file", true) ||
+    findArgumentValue(argv, "-C", false) ||
+    "cypress.json"
+  );
+}

--- a/lib/cypress-configuration.ts
+++ b/lib/cypress-configuration.ts
@@ -104,8 +104,9 @@ export function resolveConfiguration(options: {
   const {
     argv = process.argv,
     env = process.env as Record<string, string>,
-    cwd = process.cwd(),
   } = options;
+
+  const projectPath = resolveProjectPath(options);
 
   const cliOrigin: Record<string, string> = Object.fromEntries(
     Array.from(
@@ -160,7 +161,10 @@ export function resolveConfiguration(options: {
 
   let configOrigin: Record<string, any> = {};
 
-  const cypressConfigPath = path.join(cwd, resolveConfigurationFile(options));
+  const cypressConfigPath = path.join(
+    projectPath,
+    resolveConfigurationFile(options)
+  );
 
   if (fs.existsSync(cypressConfigPath)) {
     const content = fs.readFileSync(cypressConfigPath).toString("utf8");
@@ -194,8 +198,9 @@ export function resolveEnvironment(options: {
   const {
     argv = process.argv,
     env = process.env as Record<string, string>,
-    cwd = process.cwd(),
   } = options;
+
+  const projectPath = resolveProjectPath(options);
 
   const cliOrigin: Record<string, string> = Object.fromEntries(
     Array.from(
@@ -237,7 +242,10 @@ export function resolveEnvironment(options: {
       })
   );
 
-  const cypressConfigPath = path.join(cwd, resolveConfigurationFile(options));
+  const cypressConfigPath = path.join(
+    projectPath,
+    resolveConfigurationFile(options)
+  );
 
   let configOrigin: Record<string, any> = {};
 
@@ -251,7 +259,7 @@ export function resolveEnvironment(options: {
     }
   }
 
-  const cypressEnvironmentFilePath = path.join(cwd, "cypress.env.json");
+  const cypressEnvironmentFilePath = path.join(projectPath, "cypress.env.json");
 
   let cypressEnvOrigin: Record<string, any> = {};
 
@@ -284,4 +292,17 @@ export function resolveConfigurationFile(options: { argv?: string[] }): string {
     findArgumentValue(argv, "-C", false) ||
     "cypress.json"
   );
+}
+
+export function resolveProjectPath(options: {
+  argv?: string[];
+  cwd?: string;
+}): string {
+  const { argv = process.argv, cwd = process.cwd() } = options;
+
+  const customProjectPath =
+    findArgumentValue(argv, "--project", true) ||
+    findArgumentValue(argv, "-P", false);
+
+  return customProjectPath ? path.join(cwd, customProjectPath) : cwd;
 }

--- a/lib/cypress-specs.ts
+++ b/lib/cypress-specs.ts
@@ -1,0 +1,75 @@
+import path from "path";
+
+import util from "util";
+
+import glob from "glob";
+
+import minimatch from "minimatch";
+
+import { assertIsString } from "./assertions";
+
+import { resolveConfiguration } from "./cypress-configuration";
+
+const MINIMATCH_OPTIONS = { dot: true, matchBase: true };
+
+export function find(
+  options: { argv?: string[]; cwd?: string } = {}
+): string[] {
+  const {
+    integrationFolder,
+    fixturesFolder,
+    supportFile,
+    testFiles,
+    ignoreTestFiles,
+  } = resolveConfiguration(options) as {
+    integrationFolder: string;
+    fixturesFolder: string | false;
+    supportFile: string | false;
+    testFiles: string | string[];
+    ignoreTestFiles: string | string[];
+  };
+
+  const testFilesPatterns = [testFiles].flat();
+  const ignoreTestFilesPatterns = [ignoreTestFiles].flat();
+
+  assertIsString(
+    integrationFolder,
+    `Expected "integrationFolder" to be a string, got ${util.inspect(
+      integrationFolder
+    )}`
+  );
+
+  const globIgnore = [];
+
+  if (supportFile) {
+    globIgnore.push(supportFile);
+  }
+
+  if (fixturesFolder) {
+    assertIsString(
+      fixturesFolder,
+      `Expected "fixturesFolder" to be a string or false, got ${util.inspect(
+        fixturesFolder
+      )}`
+    );
+
+    globIgnore.push(path.join(fixturesFolder, "**", "*"));
+  }
+
+  const globOptions = {
+    sort: true,
+    absolute: true,
+    nodir: true,
+    cwd: integrationFolder,
+    ignore: globIgnore.flat(),
+  };
+
+  return testFilesPatterns
+    .flatMap((testFilesPattern) => glob.sync(testFilesPattern, globOptions))
+    .filter((file) =>
+      ignoreTestFilesPatterns.every(
+        (ignoreTestFilesPattern) =>
+          !minimatch(file, ignoreTestFilesPattern, MINIMATCH_OPTIONS)
+      )
+    );
+}

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
   "files": [
     "lib/**/*.js",
     "lib/**/*.d.ts",
+    "cypress-tags",
     "methods.js",
     "methods.d.ts",
     "specs-by-tags.js",
     "specs-by-tags.d.ts"
   ],
   "bin": {
+    "cypress-tags": "cypress-tags.sh",
     "specs-by-tags": "specs-by-tags.js"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "cosmiconfig": "^4.0.0",
     "debug": "^4.2.0",
     "glob": "^7.1.6",
-    "is-path-inside": "^3.0.2"
+    "is-path-inside": "^3.0.2",
+    "minimatch": "^3.0.4"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,13 @@
     "lib/**/*.js",
     "lib/**/*.d.ts",
     "methods.js",
-    "methods.d.ts"
+    "methods.d.ts",
+    "specs-by-tags.js",
+    "specs-by-tags.d.ts"
   ],
+  "bin": {
+    "specs-by-tags": "specs-by-tags.js"
+  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",

--- a/specs-by-tags.ts
+++ b/specs-by-tags.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+
+import util from "util";
+
+import { AstBuilder, Parser, compile } from "@cucumber/gherkin";
+
+import { IdGenerator } from "@cucumber/messages";
+
+import parse from "@cucumber/tag-expressions";
+
+import { assertAndReturn, assertIsString } from "./lib/assertions";
+
+import { mapTagName } from "./lib/ast-helpers";
+
+import { resolveEnvironment } from "./lib/cypress-configuration";
+
+import { find } from "./lib/cypress-specs";
+
+export { find };
+
+export function findByTags(tags: any) {
+  const files = find();
+
+  if (!tags) {
+    return files;
+  }
+
+  assertIsString(
+    tags,
+    `Expected "integrationFolder" to be a string, got ${util.inspect(tags)}`
+  );
+
+  const testFilter = parse(tags);
+
+  return files
+    .filter((file) => file.endsWith(".feature"))
+    .filter((file) => {
+      const content = fs.readFileSync(file).toString();
+      const newId = IdGenerator.incrementing();
+      const gherkinDocument = new Parser(new AstBuilder(newId)).parse(content);
+      const pickles = compile(gherkinDocument, file, newId);
+
+      return pickles.some((pickle) =>
+        testFilter.evaluate(pickle.tags?.map(mapTagName) || [])
+      );
+    });
+}
+
+if (require.main === module) {
+  const hasSpecArg = process.argv.some((arg) =>
+    arg.match(/^(?:-s|--spec(?:=|$))/)
+  );
+
+  if (hasSpecArg) {
+    console.error("-s / --spec is already defined");
+    process.exit(1);
+  }
+
+  const { TAGS } = resolveEnvironment({});
+
+  console.log(findByTags(TAGS).join(","));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
   },
   "include": [
     "lib/**/*.ts",
+    "specs-by-tags.ts",
     "methods.ts"
   ]
 }


### PR DESCRIPTION
@lgandecki , here's my idea of a different approach for implementing `cypress-tags`, as I mentioned earlier. The idea is to mimic Cypress' own resolvment algorithms as closely as possible, making things "just work". I'm thinking that the contract we promise to deliver is just that, and I'm hopeful this means that any bug can be fixed without treating it as a breaking change, because no one should have been accidentally depending on it.

What I mean by this is that when invoking `cypress-tags`, it should not matter whether you have defined `TAGS` using `--env=TAGS=foo`, using `cypress.json` at a custom location or using `cypress.env.json`. It should take all posibilities into account with the same precedence.