### PR TITLE
Ensure that every example retains its name, despite skipping

### DIFF
--- a/features/target_specific_scenarios_by_tag.feature
+++ b/features/target_specific_scenarios_by_tag.feature
@@ -42,11 +42,11 @@ Feature: target specific scenario
       | Name                             |
       | second scenario - X (example #1) |
       | second scenario - Y (example #2) |
-      | second scenario - Z (example #1) |
+      | second scenario - Z (example #3) |
 
   Scenario: run a single scenario outline examples
     When I run cypress with "--env TAGS=@d"
     Then it passes
     And it should appear to have run the scenarios
       | Name                             |
-      | second scenario - Z (example #1) |
+      | second scenario - Z (example #3) |

--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -110,6 +110,7 @@ const createTestFromScenarios = (
   allScenarios.forEach((section) => {
     if (section.examples) {
       const hasEnvTags = !!getEnvTags();
+      let index = 0;
       section.examples.forEach((example) => {
         const exampleValues = [];
         const exampleLocations = [];
@@ -127,10 +128,12 @@ const createTestFromScenarios = (
           });
         });
 
-        exampleValues.forEach((rowData, index) => {
+        exampleValues.forEach((rowData) => {
           // eslint-disable-next-line prefer-arrow-callback
           const scenarioName = replaceParameterTags(rowData, section.name);
-          const uniqueScenarioName = `${scenarioName} (example #${index + 1})`;
+          const uniqueScenarioName = `${scenarioName} (example #${
+            index++ + 1
+          })`;
           const exampleSteps = section.steps.map((step) => {
             const newStep = { ...step };
             newStep.text = replaceParameterTags(rowData, newStep.text);


### PR DESCRIPTION
I _think_ this fixes https://github.com/TheBrainFamily/cypress-cucumber-preprocessor/issues/196#issuecomment-934369229.